### PR TITLE
Update library.js

### DIFF
--- a/library.js
+++ b/library.js
@@ -4,7 +4,7 @@
 	var YoutubeLite = {},
 		embed = '<div class="js-lazyYT" data-youtube-id="$1" data-width="640" data-height="360"><iframe class="lazytube" src="//www.youtube.com/embed/$1"></iframe></div>';
 
-	var	regularUrl = /<a href="(?:https?:\/\/)?(?:www\.)?(?:youtube\.com)\/(?:watch\?v=)(.+)">.+<\/a>/g;
+	var	regularUrl = /<a href="(?:https?:\/\/)?(?:www\.)?(?:youtube\.com)\/(?:watch\?v=)([A-Za-z0-9]+)(?:\&amp;.+)?">.+<\/a>/g;
         var	shortUrl = /<a href="(?:https?:\/\/)?(?:www\.)?(?:youtu\.be)\/(.+)">.+<\/a>/g;
         var	embedUrl = /<a href="(?:https?:\/\/)?(?:www\.)youtube.com\/embed\/([\w\-_]+)">.+<\/a>/;
 


### PR DESCRIPTION
Links with &feature=youtu.be which sometimes get added by youtube, the id was being malformed like youtube-id=oELx0vfiKQg&feature=youtu.be like in https://www.youtube.com/watch?v=oELx0vfiKQg&feature=youtu.be

Added (?:\&amp;.+)? to ignore any additional get variable in the url. All tested.