### PR TITLE
Updated plugin to not use NodeBB parse hooks anymore

### DIFF
--- a/library.js
+++ b/library.js
@@ -4,9 +4,9 @@
 	var YoutubeLite = {},
 		embed = '<div class="js-lazyYT" data-youtube-id="$1" data-height="360"><iframe class="lazytube" src="//www.youtube.com/embed/$1"></iframe></div>';
 
-	var	regularUrl = /<a href="(?:https?:\/\/)?(?:www\.)?(?:youtube\.com)\/(?:watch\?v=)(.+)">.+<\/a>/g;
-        var	shortUrl = /<a href="(?:https?:\/\/)?(?:www\.)?(?:youtu\.be)\/(.+)">.+<\/a>/g;
-        var	embedUrl = /<a href="(?:https?:\/\/)?(?:www\.)youtube.com\/embed\/([\w\-_]+)">.+<\/a>/;
+    var	regularUrl = /<a href="(?:https?:\/\/)?(?:www\.)?(?:youtube\.com)\/(?:watch\?v=)(.+)">.+<\/a>/g,
+        shortUrl = /<a href="(?:https?:\/\/)?(?:www\.)?(?:youtu\.be)\/(.+)">.+<\/a>/g,
+        embedUrl = /<a href="(?:https?:\/\/)?(?:www\.)youtube.com\/embed\/([\w\-_]+)">.+<\/a>/;
 
     YoutubeLite.parse = function(data, callback) {
         if (!data || !data.postData || !data.postData.content) {
@@ -22,7 +22,29 @@
             data.postData.content = data.postData.content.replace(shortUrl, embed);
         }
         callback(null, data);
+    };
 
+    YoutubeLite.updateParser = function(parser) {
+        var renderImage = parser.renderer.rules.image || function(tokens, idx, options, env, self) {
+                renderToken.apply(self, arguments);
+            },
+            regularUrl = /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com)\/(?:watch\?v=)(.+)/,
+            shortUrl = /(?:https?:\/\/)?(?:www\.)?(?:youtu\.be)\/(.+)/,
+            embedUrl = /(?:https?:\/\/)?(?:www\.)youtube.com\/embed\/([\w\-_]+)/;
+
+        // If an image contains a youtube link, convert it!
+        parser.renderer.rules.image = function (tokens, idx, options, env, self) {
+            var src = tokens[idx].attrs[tokens[idx].attrIndex('src')][1];
+            if (regularUrl.test(src)) {
+                return src.replace(regularUrl, embed);
+            } else if (shortUrl.test(src)) {
+                return src.replace(shortUrl, embed);
+            } else if (embedUrl.test(src)) {
+                return src.replace(embedUrl, embed);
+            } else {
+                return renderImage(tokens, idx, options, env, self);
+            }
+        };
     };
 
 	module.exports = YoutubeLite;

--- a/library.js
+++ b/library.js
@@ -4,35 +4,17 @@
 	var YoutubeLite = {},
 		embed = '<div class="js-lazyYT" data-youtube-id="$1" data-height="360"><iframe class="lazytube" src="//www.youtube.com/embed/$1"></iframe></div>';
 
-    var	regularUrl = /<a href="(?:https?:\/\/)?(?:www\.)?(?:youtube\.com)\/(?:watch\?v=)(.+)">.+<\/a>/g,
-        shortUrl = /<a href="(?:https?:\/\/)?(?:www\.)?(?:youtu\.be)\/(.+)">.+<\/a>/g,
-        embedUrl = /<a href="(?:https?:\/\/)?(?:www\.)youtube.com\/embed\/([\w\-_]+)">.+<\/a>/;
-
-    YoutubeLite.parse = function(data, callback) {
-        if (!data || !data.postData || !data.postData.content) {
-            return callback(null, data);
-        }
-        if (data.postData.content.match(embedUrl)) {
-            data.postData.content = data.postData.content.replace(embedUrl, embed);
-        }
-        if (data.postData.content.match(regularUrl)) {
-            data.postData.content = data.postData.content.replace(regularUrl, embed);
-        }
-        if (data.postData.content.match(shortUrl)) {
-            data.postData.content = data.postData.content.replace(shortUrl, embed);
-        }
-        callback(null, data);
-    };
-
     YoutubeLite.updateParser = function(parser) {
         var renderImage = parser.renderer.rules.image || function(tokens, idx, options, env, self) {
-                renderToken.apply(self, arguments);
+                return renderToken.apply(self, arguments);
             },
-            regularUrl = /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com)\/(?:watch\?v=)(.+)/,
-            shortUrl = /(?:https?:\/\/)?(?:www\.)?(?:youtu\.be)\/(.+)/,
-            embedUrl = /(?:https?:\/\/)?(?:www\.)youtube.com\/embed\/([\w\-_]+)/;
+            regularUrl = /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com)\/(?:watch\?v=)([\w\-_]+)/,
+            shortUrl = /(?:https?:\/\/)?(?:www\.)?(?:youtu\.be)\/([\w\-_]+)/,
+            embedUrl = /(?:https?:\/\/)?(?:www\.)youtube.com\/embed\/([\w\-_]+)/,
+            tests = [regularUrl, shortUrl, embedUrl],
+            token;
 
-        // If an image contains a youtube link, convert it!
+        // Just for fun, if an image contains a youtube link, convert it!
         parser.renderer.rules.image = function (tokens, idx, options, env, self) {
             var src = tokens[idx].attrs[tokens[idx].attrIndex('src')][1];
             if (regularUrl.test(src)) {
@@ -42,9 +24,40 @@
             } else if (embedUrl.test(src)) {
                 return src.replace(embedUrl, embed);
             } else {
-                return renderImage(tokens, idx, options, env, self);
+                return renderImage.apply(self, arguments);
             }
         };
+
+        parser.renderer.rules['youtube-lite'] = function(tokens, idx, options, env) {
+            return '<div class="js-lazyYT" data-youtube-id="' + tokens[idx].embedId + '" data-height="360"><iframe class="lazytube" src="//www.youtube.com/embed/' + tokens[idx].embedId + '"></iframe></div>';
+        };
+
+        parser.inline.ruler.after('link', 'youtube-lite', function replace(state) {
+            var found = false;
+            tests.forEach(function(urlRegexp, idx) {
+                if (!found && urlRegexp.test(state.src)) {
+                    var match = state.src.match(urlRegexp),
+                        id = match[1],
+                        max = state.posMax;
+
+                    state.pending = state.src.slice(0, match.index);
+                    state.pos = match.index;
+                    state.posMax = state.pos + match[0].length;
+
+                    token = state.push('youtube-lite');
+                    token.embedId = id;
+
+                    state.pos = state.posMax + 1;
+                    state.posMax = max;
+
+                    state.pending = '';
+
+                    found = true;
+                }
+            });
+
+            return found;
+        });
     };
 
 	module.exports = YoutubeLite;

--- a/plugin.json
+++ b/plugin.json
@@ -1,19 +1,20 @@
 {
-	"id": "nodebb-plugin-youtube-lite",
-	"name": "NodeBB Youtube Lite",
-	"description": "NodeBB Plugin that allows users to Lazyload Youtube Videos inline in their posts.",
-	"url": "https://github.com/a5mith/nodebb-plugin-youtube-lite",
-	"library": "./library.js",
-	"hooks": [
-        { "hook": "filter:parse.post", "method": "parse", "callbacked": true }	],
-	"staticDirs": {
+    "id": "nodebb-plugin-youtube-lite",
+    "name": "NodeBB Youtube Lite",
+    "description": "NodeBB Plugin that allows users to Lazyload Youtube Videos inline in their posts.",
+    "url": "https://github.com/a5mith/nodebb-plugin-youtube-lite",
+    "library": "./library.js",
+    "hooks": [
+        { "hook": "filter:parse.post", "method": "parse", "callbacked": true }
+    ],
+    "staticDirs": {
         "static": "./static"
     },
     "less": [
         "static/style.less"
     ],
     "scripts": [
-		"static/lib/lazyYT.js",
+        "static/lib/lazyYT.js",
         "static/lib/main.js"
-	]
+    ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/a5mith/nodebb-plugin-youtube-lite",
     "library": "./library.js",
     "hooks": [
-        { "hook": "filter:parse.post", "method": "parse" },
         { "hook": "action:markdown.updateParserRules", "method": "updateParser" }
     ],
     "staticDirs": {

--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,8 @@
     "url": "https://github.com/a5mith/nodebb-plugin-youtube-lite",
     "library": "./library.js",
     "hooks": [
-        { "hook": "filter:parse.post", "method": "parse", "callbacked": true }
+        { "hook": "filter:parse.post", "method": "parse" },
+        { "hook": "action:markdown.updateParserRules", "method": "updateParser" }
     ],
     "staticDirs": {
         "static": "./static"


### PR DESCRIPTION
... and instead, rely on updating the Markdown-it parser rules directly.

This is less likely to break if the markdown plugin is updated to add more arguments to anchors, such as `rel="nofollow"`, etc.

On the other hand, it does make it incompatible if the forum owner decides not to use Markdown as a parser, so perhaps the old behaviour *should* be maintained as a fallback.

Discuss :trollface: 