### PR TITLE
safer regex to match yt links

### DIFF
--- a/library.js
+++ b/library.js
@@ -4,7 +4,7 @@
 	var YoutubeLite = {},
 		embed = '<div class="js-lazyYT" data-youtube-id="$1" data-width="640" data-height="360"><iframe class="lazytube" src="//www.youtube.com/embed/$1"></iframe></div>';
 
-	    var	regularUrl = /<a href="http.?:.*(youtube.com|.*be\/|.*embed\/|watch\?.*v=|(\w{11})).*?<\/a>/g;
+	    var	regularUrl = /<a href="https?:\/\/(?:[^\/]+\.)?(?:youtube\.com|youtu\.be)\/(?:watch)?(?:\?v=)?([^&]+)[^"]*"[^<]*<\/a>/g;
         
     YoutubeLite.parse = function(data, callback) {
         if (!data || !data.postData || !data.postData.content) {


### PR DESCRIPTION
After the last update, this plugin started to match all sorts of URLs.

I propose a more restrictive regex:

regex | meaning
------ | -------
`/<a href="http` |  
`s?` | https is optional
`:\/\/`  |  end scheme, start domain part of URL
`(?:[^\/]+\.)?`| optional sub domains, non-matching group
`(?:youtube\.com|youtu\.be)` |  youtube domains
`\/` | start path
`(?:watch)?` | optional group
`(?:\?v=)? ` | forward to `v=`, if it exists
`([A-Za-z0-9]+)` | get the video id
`[^"]*"[^<]*<\/a>/g` | rest of the html href attribute, end of href attribute closing tag
```