### PR TITLE
Remove unused youtube thumbnail image names. Fixes #21.

### DIFF
--- a/static/lib/lazyYT.js
+++ b/static/lib/lazyYT.js
@@ -92,11 +92,7 @@
         })
           .html(innerHtml.join(''));
         
-        if (width > 640) {
-            thumb_img = 'maxresdefault.jpg';
-        } else if (width > 480) {
-            thumb_img = 'sddefault.jpg';
-        } else if (width > 320) {
+        if (width > 320) {
             thumb_img = 'hqdefault.jpg';
         } else if (width > 120) {
             thumb_img = 'mqdefault.jpg';

--- a/templates/admin/plugins/youtube-lite.tpl
+++ b/templates/admin/plugins/youtube-lite.tpl
@@ -12,7 +12,7 @@
 						<form class="form youtube-lite-settings">
 							<div class="form-group">
 								<label for="id">Youtube API Key</label>
-								<input type="text" class="form-control" name="id" input id="youtubeKey" value="{settings.youtubeKey}/>
+								<input type="text" class="form-control" name="id" input id="youtubeKey" value="{settings.youtubeKey}"/>
 							</div>
 						</form>
 					</div>


### PR DESCRIPTION
Youtube only uses default, mqdefault and hqdefault thumbnail images.