### PR TITLE
Only convert when the youtube URL is the only thing on the line.

### DIFF
--- a/library.js
+++ b/library.js
@@ -4,7 +4,7 @@ var controllers = require('./lib/controllers');
 var YoutubeLite = {},
 	    embed = '<div class="js-lazyYT" data-youtube-id="$4" data-width="640" data-height="360"><iframe class="lazytube" src="//www.youtube.com/embed/$4"></iframe></div>';
 
-	var regularUrl = /<a.*?href="((https?:\/\/www\.)?youtube\.com\/\S*(?:(?:\/e(?:mbed))?\/|watch\?(?:\S*?&?v\=))|(https?:\/\/)?youtu\.be\/)([a-zA-Z0-9_-]{6,11})".*?<\/a>/g;
+	var regularUrl = /<p><a.*?href="((https?:\/\/www\.)?youtube\.com\/\S*(?:(?:\/e(?:mbed))?\/|watch\?(?:\S*?&?v\=))|(https?:\/\/)?youtu\.be\/)([a-zA-Z0-9_-]{6,11})".*?<\/a><\/p>/g;
 
 YoutubeLite.init = function(params, callback) {
 	var router = params.router,


### PR DESCRIPTION
If users put a youtube link in the middle of a paragraph or as a markdown link with text or an image inside of it, we don't want to convert that to a youtube player.
